### PR TITLE
Model improvement

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,6 +1,6 @@
 import torch
 from utils import load_data
-from models import SimpleCNN  # CNN model 
+from models import QuadCNN  # CNN model 
 from train import train_model  # Import the training function
 from viz import plot_training_history, visualize_data  # Import the plotting function
 
@@ -13,7 +13,7 @@ if __name__ == "__main__":
 
     # Training
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu") # Define device
-    model = SimpleCNN(dropout_rate=0.3)
+    model = QuadCNN(dropout_rate=0.3)
     trained_model, train_losses, test_losses, train_accuracies, test_accuracies = train_model(model, train_loader, test_loader, device=device, numerical_labels=numerical_labels) # Pass device to train_model
 
     # Saving model

--- a/models.py
+++ b/models.py
@@ -2,9 +2,9 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F  # For activation functions
 
-class SimpleCNN(nn.Module):
+class QuadCNN(nn.Module):
     def __init__(self, num_classes=3, dropout_rate=0.5):  # 3 classes: benign, malignant, normal
-        super(SimpleCNN, self).__init__()
+        super(QuadCNN, self).__init__()
         # Convolutional layers
         self.conv1 = nn.Conv2d(3, 32, kernel_size=3, padding=1)  # Increased filters
         self.conv2 = nn.Conv2d(32, 64, kernel_size=3, padding=1)  # Increased filters


### PR DESCRIPTION
As of previous update, a modified CNN architecture was used. But in models.py (where models architecture is stored) and main.py, the model was named as SimpleCNN. However, modified CNN is called QuadCNN in commits but was not updated in code. So, that mismatch is fixed.